### PR TITLE
Fix TCL 8.4 compatibility

### DIFF
--- a/slang.tcl
+++ b/slang.tcl
@@ -80,6 +80,7 @@ proc ud::handler {nick uhost hand chan argv} {
 }
 
 proc ud::output {chan def_dict} {
+	set output 0
 	foreach line [ud::split_line $ud::line_length [dict get $def_dict definition]] {
 		if {[incr output] > $ud::max_lines} {
 			if {$ud::show_truncate} {


### PR DESCRIPTION
The variable **output** is never initialized.  When running TCL 8.4, this causes the script to fail.
