### PR TITLE
Output format changes

### DIFF
--- a/slang.tcl
+++ b/slang.tcl
@@ -46,7 +46,7 @@ namespace eval ::ud {
 	variable url_random http://www.urbandictionary.com/random.php
 
 	# regex to find the word 
-	variable word_regex {<div class='word'>\s*<a href[^>]*?>([^<]*?)</a>\s*</div>\s*<div class='meaning'>}
+	variable word_regex {<div class='word'>\s*<a href[^>]*?>([^<]*?)</a>.*?*<div class='meaning'>}
 	variable list_regex {<div class='box'.*? data-defid='[0-9]+'>.*?<div class='footer'>}
 	variable def_regex {<div class='box'.*? data-defid='([0-9]+)'>.*?<div class='meaning'>(.*?)</div>}
 


### PR DESCRIPTION
Changes output format so bugs like "scott steiner is scott steiner is" don't occur.

Also removes the lowercase function being applied to the definition, to keep the definition as-is.

http://www.urbandictionary.com/define.php?term=Scott%20Steiner

> Scott Steiner is scott steiner is an american professional wrestler.being the genetic freak that he his, steiner is a one-time wcw world heavyweight champion, seven-time wcw world tag team champion, two-time wwf world tag team champion and two-time united states champion.

vs

> Scott Steiner: Scott Steiner is an American professional wrestler.Being the genetic freak that he his, Steiner is a one-time WCW World Heavyweight Champion, seven-time WCW World Tag Team Champion, two-time WWF World Tag Team Champion and two-time United States Champion.
